### PR TITLE
WIP Build odoo 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The following ports will be open on your host: 8069, 3000, 9200.
 
 Access Odoo from http://localhost:8069
 
-Login: odoo
+Login: admin
 
-Password: odoo
+Password: admin
 
 Odoo is an ERP system. It's the backend of shopinvader, where you manage products, handle sale orders, manage shipping and do the invoicing / accounting.
 

--- a/containers/odoo/Dockerfile
+++ b/containers/odoo/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/acsone/odoo-bedrock:12.0-py35-latest
+
+RUN set -e \
+  && apt update \
+  && apt -y install --no-install-recommends postgresql-client \
+  && apt -y clean \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY ./entrypoint-db /odoo/start-entrypoint.d/
+
+COPY ./requirements.txt /tmp/
+
+RUN pip install -r /tmp/requirements.txt
+

--- a/containers/odoo/entrypoint-db
+++ b/containers/odoo/entrypoint-db
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import os
+import subprocess
+
+
+db_name = os.getenv("DB_NAME")
+
+if db_name:
+    for database in db_name.split(","):
+        subprocess.check_call(
+            ["click-odoo-update", "--if-exists", "-d", database, "--i18n-overwrite"]
+        )
+        subprocess.check_call(
+            [
+                "click-odoo-initdb",
+                "--unless-exists",
+                "-n",
+                database,
+                "-m",
+                "shopinvader_demo_app,server_environment_ir_config_parameter",
+            ]
+        )
+

--- a/containers/odoo/requirements.txt
+++ b/containers/odoo/requirements.txt
@@ -1,0 +1,18 @@
+--find-links https://wheelhouse.acsone.eu/manylinux1
+--extra-index https://wheelhouse.acsone.eu/shopinvader-simple/
+--extra-index https://wheelhouse.odoo-community.org/oca-simple/
+
+# odoo + shopinvader
+-r https://raw.githubusercontent.com/odoo/odoo/12.0/requirements.txt
+https://nightly.odoo.com/12.0/nightly/src/odoo_12.0.latest.zip
+https://github.com/OCA/openupgradelib/archive/master.tar.gz
+odoo12_addon_shopinvader_demo_app
+
+
+# Used to initialize and update the odoo database with the
+# shopinvader_demor_app
+click-odoo-contrib
+
+# Get ir.config.paramter from odoo.cfg to ease the configuration
+# of odoo from the docker-compose file
+odoo12_addon_server_environment_ir_config_parameter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,9 @@ services:
   elastic:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.0.0
     environment:
-      - discovery.type=single-node
+      discovery.type: single-node
+      http.cors.enabled: "true"
+      http.cors.allow-origin: "*"
     volumes:
       - esdata:/usr/share/elasticsearch/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     volumes:
       - mongodb:/data/db
   locomotive:
-    image: quay.io/akretion/locomotive-shopinvader-demo:v4.0.x-latest
+    image: quay.io/shopinvader/locomotive-shopinvader-demo:v4.0.x-latest
     environment:
       - VIRTUAL_HOST=locomotive-shopinvader-demo.dy
       - VIRTUAL_PORT=3000
@@ -40,26 +40,44 @@ services:
     ports:
       - 9200:9200
   odoo:
-    image: quay.io/akretion/shopinvader-odoo:10.0-latest
+    build: ./containers/odoo
     volumes:
       - data-odoo:/data/odoo
     environment:
-      - PYTHONDONTWRITEBYTECODE=True
-      - DB_USER=odoo
-      - DB_PASS=odoo
-      - DB_NAME=db
-      - DB_HOST=pgdb
-      - RUNNING_ENV=dev
-      - MARABUNTA_MODE=demo
-      - DEMO=True
-      - SERVER_WIDE_MODULES=web,web_kanban,queue_job
-      - ODOO_QUEUE_JOB_CHANNELS=root:4,root.search_engine:4,root.search_engine.recompute_json:4,root.search_engine.prepare_batch_export:4
+      RUNNING_ENV: demo
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: odoo-shopinvader-demo
+      DB_HOST: pgdb
+      SERVER_WIDE_MODULES: web,queue_job
+      ODOO_QUEUE_JOB_CHANNEL: =root:4,root.search_engine:4,root.search_engine.recompute_json:4,root.search_engine.prepare_batch_export:4
+      ADMIN_PASSWD: admin
+      UNACCENT: "true"
+      LIMIT_TIME_CPU: 900
+      LIMIT_TIME_REAL: 1800
+      MAX_CRON_THREADS: 1
+      LOG_LEVEL: info
+      ADDITIONAL_ODOO_RC: |-
+        [ir.config_parameter]
+        report.url=http://odoo:8069
+        web.base.url=http://odoo:8069
+        
+        [api_key_test]
+        user=admin
+        key=123456
+      KWKHTMLTOPDF_SERVER_URL: http://kwkhtmltopdf:8080
     depends_on:
       - pgdb
       - locomotive
       - elastic
+      - kwkhtmltopdf
     ports:
       - 8069:8069
+      - 8072:8072
+  kwkhtmltopdf:
+    image: acsone/kwkhtmltopdf
+    ports:
+      - 8080:8080
   wagon:
     image: quay.io/akretion/shopinvader-wagon:latest
     ports:


### PR DESCRIPTION
The Odoo 12 image is built from quay.io/acsone/odoo-bedrock:12.0-py36-latest by installing odoo and shopinvader addons with pip https://github.com/acsone/shopinvader-getting-started/blob/build-odoo-12/containers/odoo/Dockerfile, https://github.com/acsone/shopinvader-getting-started/blob/build-odoo-12/containers/odoo/requirements.txt
The database is initialized and kept up to date thanks to click-odoo-conrtib scripts at container startup https://github.com/acsone/shopinvader-getting-started/blob/build-odoo-12/containers/odoo/entrypoint-db
wkhtml2pdf is provided by the docker image acsone/kwkhtmltopdf see https://github.com/acsone/kwkhtmltopdf for more informations

requires:
* [x]  https://github.com/acsone/odoo-bedrock/pull/8