### PR TITLE
[POC] Remove the need to give ports, change url to *.localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ $ docker-compose run wagon
 ubuntu@wagon $ bundle exec wagon deploy dev
 ```
 (For the first deploy, push the data: `$ bundle exec wagon deploy dev -d` 
+
+If you change the assets (javascript or css), you have to build then deploy:
+```sh
+$ cd shopinvader-template
+$ docker run  --rm -v `pwd`:/usr/src/app -w /usr/src/app -it node:latest bash
+root@node $ yarn
+root@node $ yarn build:dev
+root@node $ exit
+$ cd ..
+$ docker-compose run wagon
+ubuntu@wagon $ bundle exec wagon deploy dev
+```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,25 @@ The CMS Admin panel is used to create marketing content like a blog.
 Preview changes in the theme with wagon:
 
 ```sh
-$ docker-compose wagon run
+$ docker-compose run wagon
 ubuntu@wagon $ bundle exec wagon serve 
 ```
 Access http://wagon.localhost
+
+Configure the environment in template/config/deploy.yml
+(copy paste info from http://locomotive.localhost/locomotive Developpers > Wagon
+
+```yaml
+dev:
+  host: http://locomotive.localhost
+  handle: demo
+  email: demo@shopinvader.com
+  api_key: 1234
+  ``` 
+
+Deploy:
+```sh
+$ docker-compose run wagon
+ubuntu@wagon $ bundle exec wagon deploy dev
+```
+(For the first deploy, push the data: `$ bundle exec wagon deploy dev -d` 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ docker-compose https://docs.docker.com/compose/install/
 
 git (optional, you can manually download https://raw.githubusercontent.com/shopinvader/shopinvader-getting-started/master/docker-compose.yml)
 
+Port 80 should be free.
+
+Wildcard should work on localhost
+
 
 ## Run
 
@@ -22,12 +26,12 @@ docker-compose run --service-port wagon
 
 ```
 
-The following ports will be open on your host: 8069, 3000, 9200.
+The following ports will be open on your host: 80
 
 
 ## Odoo ERP
 
-Access Odoo from http://localhost:8069
+Access Odoo from http://odoo.localhost
 
 Login: admin
 
@@ -37,14 +41,24 @@ Odoo is an ERP system. It's the backend of shopinvader, where you manage product
 
 ## LocomotiveCMS
 
-E-commerce website: https://localhost:3000
+E-commerce website: https://locomotive.localhost
 
 It's the front page of the store.
 
-CMS Admin panel http://localhost:3000/locomotive
+CMS Admin panel http://locomotive.localhost/locomotive
 
 Login: demo@shopinvader.com
 
 Password: akretion
 
 The CMS Admin panel is used to create marketing content like a blog.
+
+## Wagon
+
+Preview changes in the theme with wagon:
+
+```sh
+$ docker-compose wagon run
+ubuntu@wagon $ bundle exec wagon serve 
+```
+Access http://wagon.localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,10 @@ services:
     depends_on:
       - mongodb
       - elastic
-    ports:
-      - 3000:3000
-    networks:
-      default:
-        aliases:
-          - locomotive.localtest.me
+    labels:
+      - "traefik.enable=true"
+      - "traefik.port=3000"
+      - "traefik.http.routers.locomotive.rule=Host(`locomotive.localhost`)"
   pgdb:
     environment:
       - POSTGRES_USER=odoo
@@ -41,12 +39,10 @@ services:
       http.cors.allow-origin: "*"
     volumes:
       - esdata:/usr/share/elasticsearch/data
-    ports:
-      - 9200:9200
-    networks:
-      default:
-        aliases:
-          - elastic.localtest.me
+    labels:
+      - "traefik.enable=true"
+      - "traefik.port=9200"
+      - "traefik.http.routers.elastic.rule=Host(`elastic.localhost`)"
   odoo:
     build: ./containers/odoo
     volumes:
@@ -68,29 +64,46 @@ services:
       ADDITIONAL_ODOO_RC: |-
         [ir.config_parameter]
         report.url=http://odoo:8069
-        web.base.url=http://odoo.localtest.me:8069
+        web.base.url=http://odoo.localhost
       KWKHTMLTOPDF_SERVER_URL: http://kwkhtmltopdf:8080
     depends_on:
       - pgdb
       - locomotive
       - elastic
       - kwkhtmltopdf
-    ports:
-      - 8069:8069
-      - 8072:8072
-    networks:
-      default:
-        aliases:
-          - odoo.localtest.me
+    labels:
+      - "traefik.enable=true"
+      - "traefik.port=8069"
+      - "traefik.http.routers.odoo.rule=Host(`odoo.localhost`)"
+      - "traefik.http.routers.odoo_long.rule=Host(`odoo.localhost`) && PathPrefix(`/longpolling/`)"
+      - "traefik.http.services.odoo_long.loadbalancer.server.port=8072"
   kwkhtmltopdf:
     image: acsone/kwkhtmltopdf
   wagon:
     image: quay.io/shopinvader/wagon:v4.0.x-20190919
-    ports:
-      - 3333:3333
     volumes:
       - ./template:/workspace
     entrypoint: /usr/local/bin/entrypoint gosu ubuntu bash
+    hostname: wagon
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.wagon.rule=Host(`wagon.localhost`)"
+      - "traefik.http.services.wagon.loadbalancer.server.port=3333"
+  traefik:
+      image: traefik:v2.0
+      command: --providers.docker --providers.docker.exposedbydefault=false
+      ports:
+          - "80:80"
+      volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+      networks:
+        default:
+          aliases:
+            - odoo.localhost
+            - elastic.localhost
+            - locomotive.localhost
+            - wagon.localhost
+
 version: '3'
 volumes:
   data-odoo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,11 @@ services:
       image: traefik:v2.0
       command: --providers.docker --providers.docker.exposedbydefault=false
       ports:
-          - "80:80"
+          # Please do not change the following port
+          # This demo have configured for running on the port 80
+          # changing the port will break the connexion between
+          # odoo - locomotive - elastic
+          - "127.0.0.1:80:80"
       volumes:
           - /var/run/docker.sock:/var/run/docker.sock
       networks:


### PR DESCRIPTION
Before this PR: 
There is references to `localtest.me` which don't resolve to anything and produces issues.
User has to remember that odoo is on :8069 and locomotive on :3000.

After this PR:
User goes to :  http://odoo.localhost or http://locomotive.localhost (which is more user friendly than localhost:8069 and localhost:3000 )
From locomotive: 
 - odoo is http://odoo.localhost (instead of odoo:8069)
 - elastic is http://elastic.localhost (instead of elastic:9200)
From odoo:
 - locomotive is http://locomotive.localhost (instead of locomotive:3000)
-  etc.
 
There is 2 drawback with this approach: 
- it should run on port 80
- user should have wildcard resolution (which is the case lot of linux distro) or should edit his /etc/hosts.


Alternative:
I have tried to use mdns resolution (.local names), We have to install and configure it on each image and I'm not even sure if it works on mac (because docker runs inside a virtual machine).


# Root cause:
Name resolution is different on the host and inside the container network.

There is no way to setup both public URL (for http users) and internal url (locomotive <-> odoo), in
locomotive, wagon nor Odoo· So we have to use public name everywhere.